### PR TITLE
Fix Linear built-in rule's targetBundleId

### DIFF
--- a/Sources/Yojam/App/SettingsStore.swift
+++ b/Sources/Yojam/App/SettingsStore.swift
@@ -415,9 +415,21 @@ final class SettingsStore: ObservableObject {
         // Drop built-ins that are tombstoned (either baked-in removedIds or user-deleted).
         var merged: [Rule] = []
         var seenIds = Set<UUID>()
+        let canonicalBuiltIns = Dictionary(uniqueKeysWithValues: BuiltInRules.all.map { ($0.id, $0) })
         for rule in savedRules {
             if rule.isBuiltIn && BuiltInRules.removedIds.contains(rule.id) { continue }
             if rule.isBuiltIn && deletedIds.contains(rule.id) { continue }
+            // One-shot fix for built-ins that shipped with the wrong bundle id.
+            // Replace with the current canonical built-in so the rule targets
+            // the right app and gets re-enabled.
+            if rule.isBuiltIn,
+               let badBundleId = BuiltInRules.bundleIdCorrections[rule.id],
+               rule.targetBundleId == badBundleId,
+               let canonical = canonicalBuiltIns[rule.id] {
+                merged.append(canonical)
+                seenIds.insert(rule.id)
+                continue
+            }
             merged.append(rule)
             seenIds.insert(rule.id)
         }

--- a/Sources/Yojam/Rules/BuiltInRules.swift
+++ b/Sources/Yojam/Rules/BuiltInRules.swift
@@ -10,6 +10,17 @@ enum BuiltInRules {
         UUID(uuidString: "550e8400-e29b-41d4-a716-446655440015")!, // YouTube Short
     ]
 
+    /// One-shot bundle-id corrections for built-ins that shipped with the wrong
+    /// targetBundleId. loadRules() rewrites any saved rule whose UUID matches
+    /// and whose saved targetBundleId equals `from`, replacing it with the
+    /// current canonical built-in (which also re-enables it — autoDisable
+    /// would have flipped it off because the wrong id wasn't installable).
+    static let bundleIdCorrections: [UUID: String] = [
+        // Linear shipped as "com.linear.Linear" but the actual app's
+        // CFBundleIdentifier is "com.linear".
+        UUID(uuidString: "550e8400-e29b-41d4-a716-44665544000e")!: "com.linear.Linear",
+    ]
+
     static let all: [Rule] = [
         Rule(id: UUID(uuidString: "550e8400-e29b-41d4-a716-446655440001")!,
              name: "Zoom Meetings", matchType: .urlContains, pattern: "zoom.us/j/",
@@ -61,7 +72,7 @@ enum BuiltInRules {
              isBuiltIn: true, priority: 113),
         Rule(id: UUID(uuidString: "550e8400-e29b-41d4-a716-44665544000e")!,
              name: "Linear", matchType: .domainSuffix, pattern: "linear.app",
-             targetBundleId: "com.linear.Linear", targetAppName: "Linear",
+             targetBundleId: "com.linear", targetAppName: "Linear",
              isBuiltIn: true, priority: 114),
         Rule(id: UUID(uuidString: "550e8400-e29b-41d4-a716-44665544000f")!,
              name: "Notion", matchType: .domainSuffix, pattern: "notion.so",


### PR DESCRIPTION
- The Linear built-in rule shipped as `targetBundleId: "com.linear.Linear"`, but the actual macOS app's `CFBundleIdentifier` is `com.linear` (verified against `/Applications/Linear.app/Contents/Info.plist` and [Fleet's software catalog](https://fleetdm.com/software-catalog/linear-linear-darwin)). I couldn't find any source — Linear docs, Homebrew cask, MDM catalogs — using the longer form.
- Symptom: opening the Pipeline tester and entering a `linear.app` URL returns "No Match" even with the rule visibly enabled in the list. Two paths discard the rule: `RuleEngine.autoDisableUninstalledRules` silently flips it off on every launch (LaunchServices doesn't resolve `com.linear.Linear`), and `RuleEngine.evaluate` re-checks installation per-call and would skip it for the same reason.
- Fix the constant in `BuiltInRules.swift` and add a `bundleIdCorrections: [UUID: String]` map keyed by built-in UUID. `SettingsStore.loadRules` consults it: any saved rule whose UUID is listed and whose saved `targetBundleId` equals the bad value gets replaced with the current canonical built-in, which also re-enables it (otherwise existing users would be stuck with the rule disabled in their saved data).