### PR TITLE
docs(readme): add Homebrew cask install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Every one of these goes through the same rule engine, tracker scrubber, and rewr
 Install via Homebrew:
 
 ```bash
-brew tap fluffypony/yojam
 brew install --cask yojam
 ```
 


### PR DESCRIPTION
## Summary

Updates the Homebrew installation instructions now that Yojam is available from the main Homebrew cask tap.

Users no longer need to run:

```bash
brew tap fluffypony/yojam
````

## Testing

Docs-only change; no app tests were run.

## Related

https://github.com/Homebrew/homebrew-cask/pull/266874